### PR TITLE
feat: Replace all dash in the file name by spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To be able to push the new Wiki Page, the action requires some environment varia
 * **MD_FOLDER**: (optional - default is the current folder) folder to scan for markdown files
 * **SKIP_MD**: (optional - all files will be processed) comma separated list of files to skip during the analysis (files you don't want to publish)
 * **WIKI_PUSH_MESSAGE**: (optional - sample message will use instead) Custom push message for your wiki pages.
+* **TRANSLATE_UNDERSCORE_TO_SPACE** (optional) Will translate the underscore in Markdown's names to spaces in your Wiki (disabled by default)
 
 ## Full Example (with additional actions to generate content)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,14 @@ if [ -z "$WIKI_PUSH_MESSAGE" ]; then
   WIKI_PUSH_MESSAGE='Auto Publish new pages'
 fi
 
+if [ -z "$TRANSLATE_UNDERSCORE_TO_SPACE" ]; then
+  echo "Don't translate '_' to space in Markdown's names"
+  TRANSLATE=0
+else
+  echo "Enable translation of '_' to spaces in Markdown's names"
+  TRANSLATE=1
+fi
+
 mkdir $TEMP_CLONE_FOLDER
 cd $TEMP_CLONE_FOLDER
 git init
@@ -47,9 +55,15 @@ git pull https://${GH_PAT}@github.com/$OWNER/$REPO_NAME.wiki.git
 cd ..
 
 for i in $(find $MD_FOLDER -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do
-    echo $i
+    realFileName=${i}
+    if [[ $TRANSLATE -ne 0 ]]; then
+        realFileName=${i//_/ }
+        echo "$i -> $realFileName"
+    else 
+        echo $realFileName
+    fi
     if [[ ! " ${DOC_TO_SKIP[@]} " =~ " ${i} " ]]; then
-        cp $MD_FOLDER/$i $TEMP_CLONE_FOLDER
+        cp $MD_FOLDER/$i "$TEMP_CLONE_FOLDER/${realFileName}"
     else
         echo "Skip $i as it matches the $SKIP_MD rule"
     fi


### PR DESCRIPTION
To avoid having this kind of glossary in our Wiki repo : 
<img width="250" alt="Screenshot 2020-02-18 at 16 43 14" src="https://user-images.githubusercontent.com/11467261/74751604-c4822d80-526d-11ea-91c4-98f0e7689790.png">

This PR add a feature to translate `_` to ` ` when copying the markdown files to the  wiki repo.


I've surrounded this new feature with an option (disabled by default) which can be enabled by setting the `TRANSLATE_UNDERSCORE_TO_SPACE` env variable in the action's YAML file.
