### PR TITLE
fix: file with spaces

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,7 @@ git config user.email $ACTION_MAIL
 git pull https://${GH_PAT}@github.com/$OWNER/$REPO_NAME.wiki.git
 cd ..
 
-for i in $(find $MD_FOLDER -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do
+for i in "$(find $MD_FOLDER -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';')"; do
     realFileName=${i}
     if [[ $TRANSLATE -ne 0 ]]; then
         realFileName=${i//_/ }
@@ -63,7 +63,7 @@ for i in $(find $MD_FOLDER -maxdepth 1 -type f -name '*.md' -execdir basename '{
         echo $realFileName
     fi
     if [[ ! " ${DOC_TO_SKIP[@]} " =~ " ${i} " ]]; then
-        cp $MD_FOLDER/$i "$TEMP_CLONE_FOLDER/${realFileName}"
+        cp "$MD_FOLDER/$i" "$TEMP_CLONE_FOLDER/${realFileName}"
     else
         echo "Skip $i as it matches the $SKIP_MD rule"
     fi


### PR DESCRIPTION
# Broken Script

## Why?
When file names contain spaces the copy script is broken and impossible even to ask for `space` replace with the `_` char.

## What?
Improved the loop syntax, around the find result, to take care of the correct filename, with or without spaces.
This is fixing the issue #7 