### PR TITLE
fix: updated action reference for the marketplace update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,9 @@
 name: Wiki page creator
 author: Decathlon <developers@decathlon.com>
-description: This Github action <strong>publish Wiki pages <i>with a provided markdown</i></strong> into the Wiki section of your GitHub repository.
-This action scans the folder, adds its files, and finally publishes them to the wiki.
-_That means this action requires some content markdown/wiki pages to be generated on a previous step, and located into a specific folder._
+description: This Github action <strong>publish Wiki pages <i>with a provided markdown</i></strong> into the Wiki section of your GitHub repository. This action scans the folder, adds its files, and finally publishes them to the wiki. _That means this action requires some content markdown/wiki pages to be generated on a previous step, and located into a specific folder._
 runs:
   using: 'docker'
-  image: 'docker://decathlon/wiki-page-creator-action:2.0.1'
+  image: 'docker://decathlon/wiki-page-creator-action:2.0.2'
 branding:
   icon: tag
   color: blue


### PR DESCRIPTION
# Marketplace

## Why?
The `action.yml` is used by GitHub to the public the action in the marketplace. It should be updated with the correct version we want to promote within the marketplace.

> Note: We need to find how to better manage this workflow, especially because the marketplace version is related to a tag we will create **after** we accept the pullrequest (containing the reference of the tag 👎 ). Do now know how to manage better than create 2 different PRs.

Documentation: https://help.github.com/en/actions/building-actions/publishing-actions-in-github-marketplace