### PR TITLE
fix: bug in the loop over files in MD_FOLDER

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: Decathlon <developers@decathlon.com>
 description: This Github action <strong>publish Wiki pages <i>with a provided markdown</i></strong> into the Wiki section of your GitHub repository. This action scans the folder, adds its files, and finally publishes them to the wiki. _That means this action requires some content markdown/wiki pages to be generated on a previous step, and located into a specific folder._
 runs:
   using: 'docker'
-  image: 'docker://decathlon/wiki-page-creator-action:2.0.2'
+  image: 'Dockerfile'
 branding:
   icon: tag
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,7 +54,8 @@ git config user.email $ACTION_MAIL
 git pull https://${GH_PAT}@github.com/$OWNER/$REPO_NAME.wiki.git
 cd ..
 
-for i in "$(find $MD_FOLDER -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';')"; do
+FILES=$(find $MD_FOLDER -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';')
+for i in $FILES; do
     realFileName=${i}
     if [[ $TRANSLATE -ne 0 ]]; then
         realFileName=${i//_/ }


### PR DESCRIPTION
Noticed the difference between these two implementations was causing a bug in my action when using this. See https://github.com/devlinjunker/template.webpack.fend/runs/684086991?check_suite_focus=true (`Upload READMES to Wiki`)

![Screenshot 2020-05-17 22 49 12](https://user-images.githubusercontent.com/1504590/82178460-e3a25280-9890-11ea-80df-36215c9e21e4.png)


You can see the difference with this example directory setup and the following two bash snippets:
```
// directory
-- md
  -- test.md
  -- help.md
```

### Example 1
 (I think this is what is desired in this script)
```
#!/bin/bash
FILES=$(find md -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';') 
for i in $FILES; do echo "test/${i}"; echo ""; done;
```
Output:  
```
test/test.md

test/help.md

```
### Example 2
This is what is happening in my repo I think when I run the action

```
#!/bin/bash
for i in $(find md -maxdepth 1 -type f -name '*.md' -execdir basename '{}' ';'); do echo "test/${i}"; echo ""; done;
```
Output:  
```
test/test.md
help.md

```

**NOTE:** The example above is just demonstrating with `echo`, in the wiki-page-creator-action, we are attempting to loop on the files and copy them with the line:
`cp "$MD_FOLDER/$i" "$TEMP_CLONE_FOLDER/${realFileName}"`

But I think that the effect is the same..