### PR TITLE
feat: upgraded version for marketplace

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,16 @@
+on: 
+  milestone:
+    types: [closed]
+name: Milestone Closure
+jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    steps:
+     - name: Upload Release Notes to Wiki
+       uses: docker://decathlon/wiki-page-creator-action:2.0.1
+       env:
+         GH_PAT: ${{ secrets.GH_PAT }}
+         ACTION_MAIL: youremail@mail.com
+         ACTION_NAME: yourusername
+         OWNER: yourGitHubOrganisation
+         REPO_NAME: yourGitHubRepository

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: Decathlon <developers@decathlon.com>
 description: This Github action <strong>publish Wiki pages <i>with a provided markdown</i></strong> into the Wiki section of your GitHub repository. This action scans the folder, adds its files, and finally publishes them to the wiki. _That means this action requires some content markdown/wiki pages to be generated on a previous step, and located into a specific folder._
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://decathlon/wiki-page-creator-action:2.0.3'
 branding:
   icon: tag
   color: blue


### PR DESCRIPTION
# Why?
The version in the action `yml` file is updated to point to the built docker image.

Pointing to this one: https://hub.docker.com/repository/registry-1.docker.io/decathlon/wiki-page-creator-action/builds/c6812fba-b077-4f7f-ab83-bb5ce9b3fdf3

![image](https://user-images.githubusercontent.com/139323/87599783-f8199480-c6f3-11ea-99e4-b437a7e0a6e8.png)
