### PR TITLE
feat: Support translation of image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Copy the secret key of the Token and the secret in Settings -> Secrets -> Add ne
 * **SKIP_MD**: (optional - all files will be processed) comma separated list of files to skip during the analysis (files you don't want to publish)
 * **WIKI_PUSH_MESSAGE**: (optional - sample message will use instead) Custom push message for your wiki pages.
 * **TRANSLATE_UNDERSCORE_TO_SPACE** (optional) Will translate the underscore in Markdown's names to spaces in your Wiki (disabled by default)
+* **GFX_PATH** (optional - no image support by default) Will modify all image URLs that point to files in the specified directory to absolute web URLs in every copied Markdown file for automatic image support.
 
 ## Full Example (with additional actions to generate content)
 
@@ -59,7 +60,7 @@ The following one is the workflow we are using to push the release notes to our 
 
 In this example the workflow is started `on milestone`; the first action is filtering on the `closed` action of the milestone (if milestone is created, renamed, ... the other steps are skipped).
 
-The `create-release-notes-action` creates the markdown file (check [here](https://github.com/Decathlon/release-notes-generator-action) if your need more information). 
+The `create-release-notes-action` creates the markdown file (check [here](https://github.com/Decathlon/release-notes-generator-action) if your need more information).
 The output file is stored into the `temp_release_notes`.
 
 The `wiki-page-creator-action` takes all the markdown files from the `temp_release_notes` folder (skipping a README.md file if found) and uploads them to the provided wiki repo.
@@ -67,7 +68,7 @@ The `wiki-page-creator-action` takes all the markdown files from the `temp_relea
 ### Using v2.0.0+
 
 ```YAML
-on: 
+on:
   milestone:
     types: [closed]
 name: Milestone Closure
@@ -92,6 +93,7 @@ jobs:
         OWNER: yourGitHubOrganisation
         REPO_NAME: yourGitHubRepository
         SKIP_MD: README.md
+        GFX_PATH: gfx
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: Decathlon <developers@decathlon.com>
 description: This Github action <strong>publish Wiki pages <i>with a provided markdown</i></strong> into the Wiki section of your GitHub repository. This action scans the folder, adds its files, and finally publishes them to the wiki. _That means this action requires some content markdown/wiki pages to be generated on a previous step, and located into a specific folder._
 runs:
   using: 'docker'
-  image: 'docker://decathlon/wiki-page-creator-action:2.0.3'
+  image: 'Dockerfile'
 branding:
   icon: tag
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,10 @@ else
   TRANSLATE=1
 fi
 
+if [ -z "${GFX_PATH}" ]; then
+  echo "GFX_PATH ENV is missing. Not modifying any image URLs"
+fi
+
 mkdir $TEMP_CLONE_FOLDER
 cd $TEMP_CLONE_FOLDER
 git init
@@ -60,11 +64,14 @@ for i in $FILES; do
     if [[ $TRANSLATE -ne 0 ]]; then
         realFileName=${i//_/ }
         echo "$i -> $realFileName"
-    else 
+    else
         echo $realFileName
     fi
     if [[ ! " ${DOC_TO_SKIP[@]} " =~ " ${i} " ]]; then
         cp "$MD_FOLDER/$i" "$TEMP_CLONE_FOLDER/${realFileName}"
+        if [ -n "${GFX_PATH}" ]; then # modify image URLs from relative path to absolute web URL
+            sed -i -E 's<!\[(.*)\]\(('"${GFX_PATH}"'\/.*)\)<!\[\1\]\(https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\2\)<g' "$TEMP_CLONE_FOLDER/${realFileName}"
+        fi
     else
         echo "Skip $i as it matches the $SKIP_MD rule"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,7 +70,10 @@ for i in $FILES; do
     if [[ ! " ${DOC_TO_SKIP[@]} " =~ " ${i} " ]]; then
         cp "$MD_FOLDER/$i" "$TEMP_CLONE_FOLDER/${realFileName}"
         if [ -n "${GFX_PATH}" ]; then # modify image URLs from relative path to absolute web URL
-            sed -i -E 's<!\[(.*)\]\(('"${GFX_PATH}"'\/.*)\)<!\[\1\]\(https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\2\)<g' "$TEMP_CLONE_FOLDER/${realFileName}"
+            # standard Markdown format
+            sed -i -E 's<!\[(.*)\]\(('"${GFX_PATH}"'\/.*?)\)<!\[\1\]\(https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\2\)<g' "$TEMP_CLONE_FOLDER/${realFileName}"
+            # HTML format
+            sed -i -E 's;<img src="'"${GFX_PATH}"'\/(.*?)>;<img src="https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\1><g' "$TEMP_CLONE_FOLDER/${realFileName}"
         fi
     else
         echo "Skip $i as it matches the $SKIP_MD rule"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,7 @@ for i in $FILES; do
             # standard Markdown format
             sed -i -E 's<!\[(.*)\]\(('"${GFX_PATH}"'\/.*?)\)<!\[\1\]\(https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\2\)<g' "$TEMP_CLONE_FOLDER/${realFileName}"
             # HTML format
-            sed -i -E 's;<img src="'"${GFX_PATH}"'\/(.*?)>;<img src="https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\1>;g' "$TEMP_CLONE_FOLDER/${realFileName}"
+            sed -i -E 's;<img src="('"${GFX_PATH}"'\/.*?)>;<img src="https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\1>;g' "$TEMP_CLONE_FOLDER/${realFileName}"
         fi
     else
         echo "Skip $i as it matches the $SKIP_MD rule"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,9 +71,9 @@ for i in $FILES; do
         cp "$MD_FOLDER/$i" "$TEMP_CLONE_FOLDER/${realFileName}"
         if [ -n "${GFX_PATH}" ]; then # modify image URLs from relative path to absolute web URL
             # standard Markdown format
-            sed -i -E 's<!\[(.*)\]\(('"${GFX_PATH}"'\/.*?)\)<!\[\1\]\(https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\2\)<g' "$TEMP_CLONE_FOLDER/${realFileName}"
+            sed -i -E 's|!\[(.*)\]\(('"${GFX_PATH}"'\/.*?)\)|!\[\1\]\(https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\2\)|g' "$TEMP_CLONE_FOLDER/${realFileName}"
             # HTML format
-            sed -i -E 's;<img src="('"${GFX_PATH}"'\/.*?)>;<img src="https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\1>;g' "$TEMP_CLONE_FOLDER/${realFileName}"
+            sed -i -E 's|<img src="('"${GFX_PATH}"'\/.*?)>|<img src="https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\1>|g' "$TEMP_CLONE_FOLDER/${realFileName}"
         fi
     else
         echo "Skip $i as it matches the $SKIP_MD rule"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,7 @@ for i in $FILES; do
             # standard Markdown format
             sed -i -E 's<!\[(.*)\]\(('"${GFX_PATH}"'\/.*?)\)<!\[\1\]\(https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\2\)<g' "$TEMP_CLONE_FOLDER/${realFileName}"
             # HTML format
-            sed -i -E 's;<img src="'"${GFX_PATH}"'\/(.*?)>;<img src="https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\1><g' "$TEMP_CLONE_FOLDER/${realFileName}"
+            sed -i -E 's;<img src="'"${GFX_PATH}"'\/(.*?)>;<img src="https://raw.githubusercontent.com/'"$OWNER"'/'"$REPO_NAME"'/master/'"$MD_FOLDER"'/\1>;g' "$TEMP_CLONE_FOLDER/${realFileName}"
         fi
     else
         echo "Skip $i as it matches the $SKIP_MD rule"


### PR DESCRIPTION
### Description:

This feature adds support for displaying images on the wiki that are located in `$MD_FOLDER/$GFX_PATH` directory. This is achieved by modifying every image URL that match the regex to point to the correct web URL of that image, for every copied file.

### Example:
I tested with the repo https://github.com/resizoltan/wiki_update (which I will take down after the PR)
#### Config:
```yaml
jobs:
  update-wiki:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@master
      - name: Update Wiki
        uses: resizoltan/wiki-page-creator-action@feature/gfx #  docker://decathlon/wiki-page-creator-action:latest
        env:
          ACTION_MAIL: resizoltan@gmail.com
          ACTION_NAME: resizoltan
          GH_PAT: ${{ secrets.WIKI_UPDATE_TOKEN }}
          MD_FOLDER: doc
          OWNER: resizoltan
          REPO_NAME: wiki_update
          GFX_PATH: gfx
```
#### URL modification:
!\[cat](gfx/cat.jpg) -> ! \[cat\](https://raw.githubusercontent.com/resizoltan/wiki_update/master/doc/gfx/cat.jpg)

### Notes:

- I had to change the image in action.yml for my fork to be able to test the changes. I am not sure what the correct approach here would be, I guess updating the docker image on the docker hub.
- Does not work for private repositories due to lack of access rights. 
