### PR TITLE
feat: Capitalize first letter in Markdown names

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Copy the secret key of the Token and the secret in Settings -> Secrets -> Add ne
 * **SKIP_MD**: (optional - all files will be processed) comma separated list of files to skip during the analysis (files you don't want to publish)
 * **WIKI_PUSH_MESSAGE**: (optional - sample message will use instead) Custom push message for your wiki pages.
 * **TRANSLATE_UNDERSCORE_TO_SPACE** (optional) Will translate the underscore in Markdown's names to spaces in your Wiki (disabled by default)
+* **CAPITALIZE_FIRST_LETTER** (optional) Will translate capitalize the first letter in Markdown's names in your Wiki (disabled by default)
 
 ## Full Example (with additional actions to generate content)
 
@@ -59,7 +60,7 @@ The following one is the workflow we are using to push the release notes to our 
 
 In this example the workflow is started `on milestone`; the first action is filtering on the `closed` action of the milestone (if milestone is created, renamed, ... the other steps are skipped).
 
-The `create-release-notes-action` creates the markdown file (check [here](https://github.com/Decathlon/release-notes-generator-action) if your need more information). 
+The `create-release-notes-action` creates the markdown file (check [here](https://github.com/Decathlon/release-notes-generator-action) if your need more information).
 The output file is stored into the `temp_release_notes`.
 
 The `wiki-page-creator-action` takes all the markdown files from the `temp_release_notes` folder (skipping a README.md file if found) and uploads them to the provided wiki repo.
@@ -67,7 +68,7 @@ The `wiki-page-creator-action` takes all the markdown files from the `temp_relea
 ### Using v2.0.0+
 
 ```YAML
-on: 
+on:
   milestone:
     types: [closed]
 name: Milestone Closure

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: Decathlon <developers@decathlon.com>
 description: This Github action <strong>publish Wiki pages <i>with a provided markdown</i></strong> into the Wiki section of your GitHub repository. This action scans the folder, adds its files, and finally publishes them to the wiki. _That means this action requires some content markdown/wiki pages to be generated on a previous step, and located into a specific folder._
 runs:
   using: 'docker'
-  image: 'docker://decathlon/wiki-page-creator-action:2.0.3'
+  image: 'Dockerfile'
 branding:
   icon: tag
   color: blue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,9 +72,9 @@ for i in $FILES; do
         realFileName=${realFileName^}
     fi
     if [ "$realFileName" = "$i" ]; then
-        echo "$i -> $realFileName"
-    else
         echo $realFileName
+    else
+        echo "$i -> $realFileName"
     fi
     if [[ ! " ${DOC_TO_SKIP[@]} " =~ " ${i} " ]]; then
         cp "$MD_FOLDER/$i" "$TEMP_CLONE_FOLDER/${realFileName}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,14 @@ else
   TRANSLATE=1
 fi
 
+if [ -z "$CAPITALIZE_FIRST_LETTER" ]; then
+  echo "Don't capitalize first letter in Markdown's names"
+  CAPITALIZE=0
+else
+  echo "Capitalize first letter in Markdown's names"
+  CAPITALIZE=1
+fi
+
 mkdir $TEMP_CLONE_FOLDER
 cd $TEMP_CLONE_FOLDER
 git init
@@ -59,8 +67,13 @@ for i in $FILES; do
     realFileName=${i}
     if [[ $TRANSLATE -ne 0 ]]; then
         realFileName=${i//_/ }
+    fi
+    if [[ $CAPITALIZE -ne 0 ]]; then
+        realFileName=${realFileName^}
+    fi
+    if [ "$realFileName" = "$i" ]
         echo "$i -> $realFileName"
-    else 
+    else
         echo $realFileName
     fi
     if [[ ! " ${DOC_TO_SKIP[@]} " =~ " ${i} " ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ for i in $FILES; do
     if [[ $CAPITALIZE -ne 0 ]]; then
         realFileName=${realFileName^}
     fi
-    if [ "$realFileName" = "$i" ]
+    if [ "$realFileName" = "$i" ]; then
         echo "$i -> $realFileName"
     else
         echo $realFileName


### PR DESCRIPTION
Markdown files are usually lowercase names with underscores. This PR adds support for converting the first letter in Markdown names to uppercase.

Issue with image in action.yml: see also #20 

The repository https://github.com/resizoltan/wiki_update now presents the combination of this PR and of #20.